### PR TITLE
fix(gdn-gating): replace hardcoded SM counts with dynamic device query

### DIFF
--- a/scripts/test-fix.sh
+++ b/scripts/test-fix.sh
@@ -1,0 +1,351 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# ninfer-serve Cooperative Launch Fix — Server Test Script
+# ============================================================================
+# Automates build, deploy, and verification of the fix for
+# cudaErrorCooperativeLaunchTooLarge on non-5090 GPUs.
+# ============================================================================
+
+NINFER_DIR="$HOME/ninfer"
+SERVE_PID_FILE="$HOME/ninfer/ninfer-serve.pid"
+PORT=8090
+MODEL_PATH="$HOME/ninfer/models/qwen3_3_9b.ninfer"
+BRANCH="fix/cooperative-launch-sm-count"
+TIMEOUT=600  # seconds to wait for build + startup
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[PASS]${NC} $*"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+fail() { echo -e "${RED}[FAIL]${NC} $*"; }
+info() { echo -e "${CYAN}[INFO]${NC} $*"; }
+
+trap 'fail "Script interrupted"; cleanup_on_fail; exit 1' INT TERM
+
+# ============================================================================
+# Functions
+# ============================================================================
+
+cleanup_on_fail() {
+    info "Cleaning up failed deployment..."
+    if [ -f "$SERVE_PID_FILE" ]; then
+        local pid
+        pid=$(cat "$SERVE_PID_FILE" 2>/dev/null || true)
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+        rm -f "$SERVE_PID_FILE"
+    fi
+}
+
+stop_serve() {
+    info "Stopping existing ninfer-serve..."
+    if [ -f "$SERVE_PID_FILE" ]; then
+        local pid
+        pid=$(cat "$SERVE_PID_FILE" 2>/dev/null || true)
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+            sleep 3
+            kill -9 "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+            log "Stopped existing serve (PID $pid)"
+        else
+            warn "Stale PID file found ($pid), removing"
+        fi
+        rm -f "$SERVE_PID_FILE"
+    fi
+
+    # Also kill any remaining serve processes
+    pkill -f "ninfer-serve.*$PORT" 2>/dev/null || true
+    sleep 2
+}
+
+wait_for_ready() {
+    local elapsed=0
+    local interval=5
+    info "Waiting for ninfer-serve to be ready (timeout: ${TIMEOUT}s)..."
+
+    while [ $elapsed -lt $TIMEOUT ]; do
+        if curl -sf "http://localhost:$PORT/health" > /dev/null 2>&1; then
+            log "Server is ready after ${elapsed}s"
+            return 0
+        fi
+        if ! [ -f "$SERVE_PID_FILE" ]; then
+            fail "Serve process died unexpectedly"
+            return 1
+        fi
+        sleep $interval
+        elapsed=$((elapsed + interval))
+    done
+
+    fail "Server did not become ready within ${TIMEOUT}s"
+    return 1
+}
+
+run_inference_test() {
+    local prompt="$1"
+    local expected_pattern="$2"
+    local test_name="$3"
+    local max_tokens="${4:-128}"
+
+    info "Running test: $test_name"
+    info "Prompt: ${prompt:0:80}..."
+
+    local response
+    response=$(curl -sf -X POST "http://localhost:$PORT/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -d "{
+            \"model\": \"qwen3_5_9b\",
+            \"messages\": [{\"role\": \"user\", \"content\": \"$prompt\"}],
+            \"max_tokens\": $max_tokens,
+            \"temperature\": 0.1,
+            \"stream\": false
+        }" 2>&1) || {
+        fail "Test '$test_name': HTTP request failed"
+        echo "$response"
+        return 1
+    }
+
+    if echo "$response" | grep -q '"error"'; then
+        fail "Test '$test_name': API returned error"
+        echo "$response" | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin), indent=2))" 2>/dev/null || echo "$response"
+        return 1
+    fi
+
+    local content
+    content=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'])" 2>/dev/null || true)
+
+    if [ -z "$content" ]; then
+        fail "Test '$test_name': Empty response"
+        return 1
+    fi
+
+    if [ -n "$expected_pattern" ] && ! echo "$content" | grep -qi "$expected_pattern"; then
+        warn "Test '$test_name': Response didn't match expected pattern '$expected_pattern'"
+        warn "Response: ${content:0:200}"
+    else
+        log "Test '$test_name': OK (${#content} chars)"
+    fi
+
+    return 0
+}
+
+run_benchmark() {
+    local num_requests="${1:-5}"
+    local tokens="${2:-256}"
+
+    info "Running benchmark: $num_requests requests x $tokens tokens..."
+
+    local success=0
+    local failed=0
+    local start_time end_time total_time
+
+    start_time=$(date +%s)
+
+    for i in $(seq 1 $num_requests); do
+        local response
+        response=$(curl -sf -X POST "http://localhost:$PORT/v1/chat/completions" \
+            -H "Content-Type: application/json" \
+            -d "{
+                \"model\": \"qwen3_5_9b\",
+                \"messages\": [{\"role\": \"user\", \"content\": \"Write a numbered list from 1 to $((i * 5))\"}],
+                \"max_tokens\": $tokens,
+                \"temperature\": 0.1,
+                \"stream\": false
+            }" 2>&1) || {
+            fail "Benchmark request $i failed"
+            failed=$((failed + 1))
+            continue
+        }
+
+        if echo "$response" | grep -q '"error"'; then
+            fail "Benchmark request $i: API error"
+            failed=$((failed + 1))
+        else
+            success=$((success + 1))
+        fi
+    done
+
+    end_time=$(date +%s)
+    total_time=$((end_time - start_time))
+
+    info "Benchmark complete: $success/$num_requests succeeded in ${total_time}s"
+
+    if [ $success -eq $num_requests ]; then
+        log "All benchmark requests passed"
+        return 0
+    elif [ $success -gt 0 ]; then
+        warn "$failed benchmark requests failed"
+        return 1
+    else
+        fail "All benchmark requests failed"
+        return 1
+    fi
+}
+
+check_cuda_errors() {
+    info "Checking for CUDA cooperative launch errors in serve logs..."
+
+    # Check dmesg and any error output
+    local errors=""
+    errors=$(dmesg 2>/dev/null | grep -i "cuda\|cooperative\|launch" | tail -5 || true)
+
+    if [ -n "$errors" ]; then
+        warn "CUDA-related messages in dmesg:"
+        echo "$errors"
+    else
+        log "No CUDA cooperative launch errors detected"
+    fi
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+info "=============================================="
+info "  ninfer-serve Cooperative Launch Fix Test"
+info "=============================================="
+info ""
+
+# Step 1: Verify we're on the right branch
+info "Step 1: Verifying git branch..."
+cd "$NINFER_DIR"
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" = "$BRANCH" ]; then
+    log "On correct branch: $BRANCH"
+else
+    fail "Expected branch '$BRANCH', got '$CURRENT_BRANCH'"
+    exit 1
+fi
+
+# Step 2: Pull latest changes
+info "Step 2: Pulling latest changes..."
+git pull origin "$BRANCH"
+log "Latest changes pulled"
+
+# Step 3: Build
+info "Step 3: Building project..."
+BUILD_START=$(date +%s)
+cd "$NINFER_DIR"
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release > /dev/null 2>&1
+cmake --build build --parallel > /dev/null 2>&1
+BUILD_END=$(date +%s)
+BUILD_TIME=$((BUILD_END - BUILD_START))
+log "Build completed in ${BUILD_TIME}s"
+
+# Verify binary exists
+if [ ! -x "$NINFER_DIR/build/apps/ninfer-serve" ]; then
+    fail "Built binary not found at $NINFER_DIR/build/apps/ninfer-serve"
+    exit 1
+fi
+log "Binary verified"
+
+# Step 4: Stop existing serve
+stop_serve
+
+# Step 5: Start new serve
+info "Step 5: Starting ninfer-serve with new binary..."
+cd "$NINFER_DIR"
+./build/apps/ninfer-serve \
+    "$MODEL_PATH" \
+    --host 0.0.0.0 \
+    --port $PORT \
+    --max-context 8192 \
+    --prefill-chunk 4096 \
+    --kv-dtype int8 \
+    --greedy \
+    --spec mtp \
+    --draft-tokens 3 \
+    > "$NINFER_DIR/serve.log" 2>&1 &
+SERVE_PID=$!
+echo $SERVE_PID > "$SERVE_PID_FILE"
+
+info "Started ninfer-serve (PID: $SERVE_PID)"
+
+# Step 6: Wait for server to be ready
+if ! wait_for_ready; then
+    fail "Server failed to start"
+    info "Serve logs:"
+    tail -50 "$NINFER_DIR/serve.log" 2>/dev/null || true
+    cleanup_on_fail
+    exit 1
+fi
+
+# Step 7: Run inference tests
+info ""
+info "=============================================="
+info "  Inference Tests"
+info "=============================================="
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+# Test 1: Basic math (verifies model is responding)
+if run_inference_test "What is 2 + 2?" "[Tt]wo|[Tt]welve|[Ff]our|4" "Basic math (2+2)"; then
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+# Test 2: List generation (tests token generation)
+if run_inference_test "List the first 5 prime numbers" "[Pp]rime|[2357]|prime" "Prime numbers list"; then
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+# Test 3: Longer context (stress test the GDN gating)
+if run_inference_test "Write a short story about a robot learning to code. Keep it under 100 words." "[Rr]obot|[Cc]ode|[Ss]tory" "Short story generation"; then
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+# Step 8: Run benchmark
+info ""
+info "=============================================="
+info "  Benchmark Tests"
+info "=============================================="
+
+if run_benchmark 5 128; then
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+# Step 9: Check for CUDA errors
+check_cuda_errors
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+info ""
+info "=============================================="
+info "  Test Summary"
+info "=============================================="
+info "  Inference tests: $TEST_PASSED passed, $TEST_FAILED failed"
+info ""
+
+if [ $TEST_FAILED -eq 0 ]; then
+    log "ALL TESTS PASSED"
+    info ""
+    info "The fix appears to be working correctly on this GPU."
+    info "Serve is still running on port $PORT if you need to do manual testing."
+else
+    fail "$TEST_FAILED test(s) failed"
+    info ""
+    info "Check the serve logs: tail -f $NINFER_DIR/serve.log"
+    info "Consider: $(warn 'ssh kuroko@192.168.1.23 \"tail -100 ~/ninfer/serve.log\"')"
+    cleanup_on_fail
+    exit 1
+fi
+
+exit 0

--- a/scripts/test-fix.sh
+++ b/scripts/test-fix.sh
@@ -14,6 +14,7 @@ PORT=8090
 MODEL_PATH="$HOME/ninfer/models/qwen3_5_9b.ninfer"
 BRANCH="fix/cooperative-launch-sm-count"
 TIMEOUT=120  # seconds to wait for server startup
+MODEL_ID=""  # auto-detected from the serve startup log
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -112,6 +113,19 @@ wait_for_ready() {
     return 1
 }
 
+detect_model_id() {
+    # The server logs its model id at startup, e.g. "(model id: qwen3.6-27b, ...)".
+    # Using the wrong id makes every request 404, so detect it from the log.
+    local log
+    log=$(cat "$NINFER_DIR/serve.log" 2>/dev/null || true)
+    MODEL_ID=$(echo "$log" | grep -o 'model id: [^)]*' | head -1 | sed 's/^model id: //' || true)
+    if [ -z "$MODEL_ID" ]; then
+        warn "Could not detect model id from serve.log; defaulting to 'qwen3.6-27b'"
+        MODEL_ID="qwen3.6-27b"
+    fi
+    log "Using model id: $MODEL_ID"
+}
+
 run_inference_test() {
     local prompt="$1"
     local expected_pattern="$2"
@@ -125,7 +139,7 @@ run_inference_test() {
     response=$(curl -sf -X POST "http://localhost:$PORT/v1/chat/completions" \
         -H "Content-Type: application/json" \
         -d "{
-            \"model\": \"qwen3_5_9b\",
+            \"model\": \"$MODEL_ID\",
             \"messages\": [{\"role\": \"user\", \"content\": \"$prompt\"}],
             \"max_tokens\": $max_tokens,
             \"temperature\": 0.1,
@@ -177,7 +191,7 @@ run_benchmark() {
         response=$(curl -sf -X POST "http://localhost:$PORT/v1/chat/completions" \
             -H "Content-Type: application/json" \
             -d "{
-                \"model\": \"qwen3_5_9b\",
+                \"model\": \"$MODEL_ID\",
                 \"messages\": [{\"role\": \"user\", \"content\": \"Write a numbered list from 1 to $((i * 5))\"}],
                 \"max_tokens\": $tokens,
                 \"temperature\": 0.1,
@@ -309,6 +323,7 @@ if ! wait_for_ready; then
     cleanup_on_fail
     exit 1
 fi
+detect_model_id
 
 # Step 7: Run inference tests
 info ""

--- a/scripts/test-fix.sh
+++ b/scripts/test-fix.sh
@@ -118,7 +118,7 @@ detect_model_id() {
     # Using the wrong id makes every request 404, so detect it from the log.
     local log
     log=$(cat "$NINFER_DIR/serve.log" 2>/dev/null || true)
-    MODEL_ID=$(echo "$log" | grep -o 'model id: [^)]*' | head -1 | sed 's/^model id: //' || true)
+    MODEL_ID=$(echo "$log" | grep -o 'model id: [^,)]*' | head -1 | sed 's/^model id: //' || true)
     if [ -z "$MODEL_ID" ]; then
         warn "Could not detect model id from serve.log; defaulting to 'qwen3.6-27b'"
         MODEL_ID="qwen3.6-27b"
@@ -130,7 +130,7 @@ run_inference_test() {
     local prompt="$1"
     local expected_pattern="$2"
     local test_name="$3"
-    local max_tokens="${4:-128}"
+    local max_tokens="${4:-512}"
 
     info "Running test: $test_name"
     info "Prompt: ${prompt:0:80}..."
@@ -157,7 +157,11 @@ run_inference_test() {
     fi
 
     local content
-    content=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'])" 2>/dev/null || true)
+    content=$(echo "$response" | python3 -c "
+import sys, json
+msg = json.load(sys.stdin)['choices'][0]['message']
+print((msg.get('content') or '') + (msg.get('reasoning_content') or ''))
+" 2>/dev/null || true)
 
     if [ -z "$content" ]; then
         fail "Test '$test_name': Empty response"

--- a/scripts/test-fix.sh
+++ b/scripts/test-fix.sh
@@ -11,9 +11,9 @@ set -euo pipefail
 NINFER_DIR="$HOME/ninfer"
 SERVE_PID_FILE="$HOME/ninfer/ninfer-serve.pid"
 PORT=8090
-MODEL_PATH="$HOME/ninfer/models/qwen3_3_9b.ninfer"
+MODEL_PATH="$HOME/ninfer/models/qwen3_5_9b.ninfer"
 BRANCH="fix/cooperative-launch-sm-count"
-TIMEOUT=600  # seconds to wait for build + startup
+TIMEOUT=120  # seconds to wait for server startup
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -47,38 +47,61 @@ cleanup_on_fail() {
 
 stop_serve() {
     info "Stopping existing ninfer-serve..."
+
+    # Kill whatever is listening on our port (works regardless of PID file).
+    local port_pid
+    port_pid=$(ss -tlnp 2>/dev/null | awk -v p=":$PORT " '$4 ~ p {print $NF}' | grep -o '[0-9]*' | head -1 || true)
+    if [ -n "$port_pid" ] && kill -0 "$port_pid" 2>/dev/null; then
+        kill "$port_pid" 2>/dev/null || true
+        sleep 3
+        kill -9 "$port_pid" 2>/dev/null || true
+        log "Stopped serve on port $PORT (PID $port_pid)"
+    fi
+
+    # Clean up any PID file from a previous run.
     if [ -f "$SERVE_PID_FILE" ]; then
-        local pid
-        pid=$(cat "$SERVE_PID_FILE" 2>/dev/null || true)
-        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-            kill "$pid" 2>/dev/null || true
+        local saved_pid
+        saved_pid=$(cat "$SERVE_PID_FILE" 2>/dev/null || true)
+        if [ -n "$saved_pid" ] && [ "$saved_pid" != "$port_pid" ] && kill -0 "$saved_pid" 2>/dev/null; then
+            kill "$saved_pid" 2>/dev/null || true
             sleep 3
-            kill -9 "$pid" 2>/dev/null || true
-            wait "$pid" 2>/dev/null || true
-            log "Stopped existing serve (PID $pid)"
-        else
-            warn "Stale PID file found ($pid), removing"
+            kill -9 "$saved_pid" 2>/dev/null || true
+            log "Stopped stale serve (PID $saved_pid)"
         fi
         rm -f "$SERVE_PID_FILE"
     fi
 
-    # Also kill any remaining serve processes
-    pkill -f "ninfer-serve.*$PORT" 2>/dev/null || true
-    sleep 2
+    # Belt-and-suspenders: kill any remaining ninfer-serve process.
+    pkill -f "ninfer-serve" 2>/dev/null || true
+
+    # Wait until the port is actually free.
+    local attempts=0
+    while ss -tln | grep -q ":$PORT " && [ $attempts -lt 15 ]; do
+        sleep 1
+        attempts=$((attempts + 1))
+    done
+    if ss -tln | grep -q ":$PORT "; then
+        fail "Port $PORT still in use after stopping serve"
+        return 1
+    fi
+    log "Port $PORT is free"
 }
 
 wait_for_ready() {
     local elapsed=0
     local interval=5
-    info "Waiting for ninfer-serve to be ready (timeout: ${TIMEOUT}s)..."
+    local pid
+    pid=$(cat "$SERVE_PID_FILE" 2>/dev/null || true)
+    info "Waiting for ninfer-serve to be ready (timeout: ${TIMEOUT}s, PID $pid)..."
 
     while [ $elapsed -lt $TIMEOUT ]; do
         if curl -sf "http://localhost:$PORT/health" > /dev/null 2>&1; then
             log "Server is ready after ${elapsed}s"
             return 0
         fi
-        if ! [ -f "$SERVE_PID_FILE" ]; then
-            fail "Serve process died unexpectedly"
+        # If we have a PID and the process is no longer alive, it died — fail fast.
+        if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+            fail "Serve process (PID $pid) died unexpectedly after ${elapsed}s"
             return 1
         fi
         sleep $interval
@@ -246,6 +269,15 @@ if [ ! -x "$NINFER_DIR/build/apps/ninfer-serve" ]; then
     exit 1
 fi
 log "Binary verified"
+
+# Verify the model file exists before we start the server.
+if [ ! -f "$MODEL_PATH" ]; then
+    fail "Model file not found: $MODEL_PATH"
+    info "Available models in $HOME/ninfer/models/:"
+    ls -1 "$HOME/ninfer/models/" 2>/dev/null || true
+    exit 1
+fi
+log "Model verified: $MODEL_PATH"
 
 # Step 4: Stop existing serve
 stop_serve

--- a/src/ops/gdn_gating_proj/bf16/bf16_gdn_gating_proj_plan.cpp
+++ b/src/ops/gdn_gating_proj/bf16/bf16_gdn_gating_proj_plan.cpp
@@ -127,11 +127,41 @@ bool cooperative_grid_is_resident(Bf16GdnGatingScheduleId schedule, std::int32_t
     return grid_ctas <= resident_ctas;
 }
 
+// Runtime residency check that uses the actual device SM count instead of hardcoded RTX 5090 values.
+// Split32 admits 2 CTAs/SM; all other cooperative schedules admit 4 CTAs/SM.
+static bool runtime_cooperative_grid_is_resident(Bf16GdnGatingScheduleId schedule,
+                                                 std::int32_t cols, std::int32_t tile_cols,
+                                                 std::int32_t row_tiles, int sm_count) noexcept {
+    const std::int64_t column_tiles =
+        (static_cast<std::int64_t>(cols) + tile_cols - 1) / tile_cols;
+    const std::int64_t grid_ctas =
+        column_tiles * row_tiles * static_cast<std::int64_t>(schedule_split_k(schedule));
+    const std::int32_t max_ctas =
+        schedule == Bf16GdnGatingScheduleId::MmaCooperativeSplit32 ? sm_count * 2 : sm_count * 4;
+    return grid_ctas <= max_ctas;
+}
+
+static int device_sm_count() noexcept {
+    static int cached = -1;
+    if (cached < 0) {
+        cudaDeviceProp prop;
+        if (cudaGetDeviceProperties(&prop, 0) == cudaSuccess) {
+            cached = prop.multiProcessorCount;
+        } else {
+            cached = 170; // fallback to RTX 5090 value
+        }
+    }
+    return cached;
+}
+
 bool cooperative_27_grid_is_resident(Bf16GdnGatingScheduleId schedule, std::int32_t cols) noexcept {
     // BN128 uses 40 KiB of dynamic shared memory. Split8 uses 71 registers with 256 threads;
     // split4/2 use 62 registers with 512 threads. Each specialization admits two CTAs/SM, hence
-    // 340 resident CTAs device-wide. There are three 16-row tiles per token tile.
-    return cooperative_grid_is_resident(schedule, cols, 128, 3, 340);
+    // 340 resident CTAs device-wide on RTX 5090. There are three 16-row tiles per token tile.
+    // Use runtime SM count for cross-GPU correctness.
+    int sm = device_sm_count();
+    const std::int32_t resident_ctas = sm * 2; // Split8 admits 2 CTAs/SM
+    return cooperative_grid_is_resident(schedule, cols, 128, 3, resident_ctas);
 }
 
 bool cooperative_35_grid_is_resident(Bf16GdnGatingScheduleId schedule, std::int32_t cols) noexcept {
@@ -139,8 +169,10 @@ bool cooperative_35_grid_is_resident(Bf16GdnGatingScheduleId schedule, std::int3
     // 13.1/sm_120a build, split32 uses 91/93 registers per thread and admits two CTAs/SM;
     // split16/8/4/2 use at most 62 registers and admit four CTAs/SM. Across 170 SMs the
     // device-wide limits are 340 and 680 CTAs respectively.
+    // Use runtime SM count for cross-GPU correctness.
+    int sm = device_sm_count();
     const std::int32_t resident_ctas =
-        schedule == Bf16GdnGatingScheduleId::MmaCooperativeSplit32 ? 340 : 680;
+        schedule == Bf16GdnGatingScheduleId::MmaCooperativeSplit32 ? sm * 2 : sm * 4;
     return cooperative_grid_is_resident(schedule, cols, 64, 2, resident_ctas);
 }
 
@@ -395,19 +427,67 @@ Bf16GdnGatingPlan bf16_gdn_gating_resolve_plan(const Bf16GdnGatingProblem& probl
         throw std::invalid_argument(
             "BF16 GDN gating: exact problem or column count is not admitted");
     }
+
+    // Build the ordered schedule list for this problem variant.
+    // Most cooperative (highest split_k) to least (Unsplit = split_k 1).
+    std::array<Bf16GdnGatingScheduleId, 6> fallback_chain{};
+    std::size_t chain_len = 0;
+
+    if (is_27(problem)) {
+        fallback_chain = {{
+            Bf16GdnGatingScheduleId::MmaCooperativeSplit8,
+            Bf16GdnGatingScheduleId::MmaCooperativeSplit4,
+            Bf16GdnGatingScheduleId::MmaCooperativeSplit2,
+            Bf16GdnGatingScheduleId::MmaUnsplit,
+        }};
+        chain_len = 4;
+    } else {
+        fallback_chain = {{
+            Bf16GdnGatingScheduleId::MmaCooperativeSplit16,
+            Bf16GdnGatingScheduleId::MmaCooperativeSplit8,
+            Bf16GdnGatingScheduleId::MmaCooperativeSplit4,
+            Bf16GdnGatingScheduleId::MmaCooperativeSplit2,
+            Bf16GdnGatingScheduleId::MmaUnsplit,
+        }};
+        chain_len = 5;
+    }
+
+    // Find which schedule the route table selects for this problem's cols.
+    Bf16GdnGatingScheduleId preferred = Bf16GdnGatingScheduleId::MmaUnsplit;
     if (is_27(problem)) {
         for (const RouteSpec& route : k27Routes) {
             if (route.cols.contains(problem.cols)) {
-                return bf16_gdn_gating_resolve_candidate(route.schedule, problem);
+                preferred = route.schedule;
+                break;
             }
         }
     } else {
         for (const RouteSpec& route : k35Routes) {
             if (route.cols.contains(problem.cols)) {
-                return bf16_gdn_gating_resolve_candidate(route.schedule, problem);
+                preferred = route.schedule;
+                break;
             }
         }
     }
+
+    // Try preferred schedule first, then fall back to less-cooperative schedules.
+    // This ensures we pick the most aggressive schedule that fits the current GPU.
+    bool tried_preferred = false;
+    for (std::size_t i = 0; i < chain_len; ++i) {
+        Bf16GdnGatingScheduleId s = fallback_chain[i];
+        if (s == preferred && !tried_preferred) {
+            tried_preferred = true;
+        } else if (s != preferred) {
+            continue;
+        }
+        try {
+            return bf16_gdn_gating_resolve_candidate(s, problem);
+        } catch (const std::invalid_argument&) {
+            // Schedule not legal for this problem on this device (e.g. residency limit).
+            // Continue to next fallback.
+        }
+    }
+
     throw std::logic_error("BF16 GDN gating: admitted problem has no covering route");
 }
 

--- a/src/ops/gdn_gating_proj/bf16/bf16_gdn_gating_proj_plan.cpp
+++ b/src/ops/gdn_gating_proj/bf16/bf16_gdn_gating_proj_plan.cpp
@@ -428,31 +428,23 @@ Bf16GdnGatingPlan bf16_gdn_gating_resolve_plan(const Bf16GdnGatingProblem& probl
             "BF16 GDN gating: exact problem or column count is not admitted");
     }
 
-    // Build the ordered schedule list for this problem variant.
-    // Most cooperative (highest split_k) to least (Unsplit = split_k 1).
-    std::array<Bf16GdnGatingScheduleId, 6> fallback_chain{};
-    std::size_t chain_len = 0;
+    // Ordered most-aggressive to least-aggressive cooperative Mma schedules for this
+    // variant. MmaUnsplit (split_k 1, no cooperative launch) is always legal and is
+    // used as a guaranteed terminal fallback below.
+    const std::array<Bf16GdnGatingScheduleId, 4> cooperative_chain =
+        is_27(problem)
+            ? std::array<Bf16GdnGatingScheduleId, 4>{
+                  {Bf16GdnGatingScheduleId::MmaCooperativeSplit8,
+                   Bf16GdnGatingScheduleId::MmaCooperativeSplit4,
+                   Bf16GdnGatingScheduleId::MmaCooperativeSplit2,
+                   Bf16GdnGatingScheduleId::MmaUnsplit}}
+            : std::array<Bf16GdnGatingScheduleId, 4>{
+                  {Bf16GdnGatingScheduleId::MmaCooperativeSplit16,
+                   Bf16GdnGatingScheduleId::MmaCooperativeSplit8,
+                   Bf16GdnGatingScheduleId::MmaCooperativeSplit4,
+                   Bf16GdnGatingScheduleId::MmaCooperativeSplit2}};
 
-    if (is_27(problem)) {
-        fallback_chain = {{
-            Bf16GdnGatingScheduleId::MmaCooperativeSplit8,
-            Bf16GdnGatingScheduleId::MmaCooperativeSplit4,
-            Bf16GdnGatingScheduleId::MmaCooperativeSplit2,
-            Bf16GdnGatingScheduleId::MmaUnsplit,
-        }};
-        chain_len = 4;
-    } else {
-        fallback_chain = {{
-            Bf16GdnGatingScheduleId::MmaCooperativeSplit16,
-            Bf16GdnGatingScheduleId::MmaCooperativeSplit8,
-            Bf16GdnGatingScheduleId::MmaCooperativeSplit4,
-            Bf16GdnGatingScheduleId::MmaCooperativeSplit2,
-            Bf16GdnGatingScheduleId::MmaUnsplit,
-        }};
-        chain_len = 5;
-    }
-
-    // Find which schedule the route table selects for this problem's cols.
+    // Find the schedule the route table prefers for this problem's cols.
     Bf16GdnGatingScheduleId preferred = Bf16GdnGatingScheduleId::MmaUnsplit;
     if (is_27(problem)) {
         for (const RouteSpec& route : k27Routes) {
@@ -470,25 +462,30 @@ Bf16GdnGatingPlan bf16_gdn_gating_resolve_plan(const Bf16GdnGatingProblem& probl
         }
     }
 
-    // Try preferred schedule first, then fall back to less-cooperative schedules.
-    // This ensures we pick the most aggressive schedule that fits the current GPU.
-    bool tried_preferred = false;
-    for (std::size_t i = 0; i < chain_len; ++i) {
-        Bf16GdnGatingScheduleId s = fallback_chain[i];
-        if (s == preferred && !tried_preferred) {
-            tried_preferred = true;
-        } else if (s != preferred) {
-            continue;
-        }
-        try {
-            return bf16_gdn_gating_resolve_candidate(s, problem);
-        } catch (const std::invalid_argument&) {
-            // Schedule not legal for this problem on this device (e.g. residency limit).
-            // Continue to next fallback.
-        }
+    // Non-cooperative schedules (Gemv/SmallT) or Unsplit carry no residency constraint.
+    if (!schedule_uses_mma(preferred) ||
+        preferred == Bf16GdnGatingScheduleId::MmaUnsplit) {
+        return bf16_gdn_gating_resolve_candidate(preferred, problem);
     }
 
-    throw std::logic_error("BF16 GDN gating: admitted problem has no covering route");
+    // Cooperative schedule: find its index in the chain, then step DOWN from there
+    // toward less-aggressive schedules until one fits this device's SM count.
+    // MmaUnsplit is guaranteed to fit and terminates the search.
+    std::size_t start = cooperative_chain.size();
+    for (std::size_t i = 0; i < cooperative_chain.size(); ++i) {
+        if (cooperative_chain[i] == preferred) {
+            start = i;
+            break;
+        }
+    }
+    for (std::size_t i = start; i < cooperative_chain.size(); ++i) {
+        try {
+            return bf16_gdn_gating_resolve_candidate(cooperative_chain[i], problem);
+        } catch (const std::invalid_argument&) {
+            // Residency check failed for this schedule on the current device; step down.
+        }
+    }
+    return bf16_gdn_gating_resolve_candidate(Bf16GdnGatingScheduleId::MmaUnsplit, problem);
 }
 
 std::size_t bf16_gdn_gating_capacity_workspace_bytes(std::int32_t heads, std::int32_t input_rows,


### PR DESCRIPTION
## Problem

`ninfer-serve` crashes with `cudaErrorCooperativeLaunchTooLarge` on RTX 5060 Ti (and likely all non-5090 Blackwell GPUs).

The root cause is hardcoded CTA residency limits calibrated for RTX 5090's 170 SMs in `bf16_gdn_gating_proj_plan.cpp`:
- `cooperative_27_grid_is_resident()` hardcodes 340 resident CTAs
- `cooperative_35_grid_is_resident()` hardcodes 340/680 resident CTAs

An RTX 5060 Ti has ~40 SMs, so the real limits are ~80/~160 — the hardcoded values are 4-8x too high.

## Fix

**Dynamic SM count query** (`device_sm_count()`): Lazily queries `cudaDeviceProp.multiProcessorCount` once and caches the result. Falls back to 170 (RTX 5090) if the query fails.

**Runtime residency checks**: Both `cooperative_27_grid_is_resident()` and `cooperative_35_grid_is_resident()` now compute limits as `sm * 2` or `sm * 4` based on the actual device, matching the CTA-per-SM admission rates documented in the comments.

**Fallback chain** in `bf16_gdn_gating_resolve_plan()`: After the route table selects a preferred schedule, the resolver tries it first. If the residency check fails (throws), it steps down through progressively less-cooperative schedules (Split16 → Split8 → Split4 → Split2 → Unsplit) until one fits. This ensures maximum performance on any GPU while guaranteeing the launch succeeds.

## Testing

The user will deploy this to the RTX 5060 Ti server and run the benchmark tests. On RTX 5090, behavior is unchanged (fallback to cached 170 SM value).