### PR TITLE
fix(media): convert deprecated YUVJ pixel formats to standard YUV before swscaler

### DIFF
--- a/src/media/decode/decode.cpp
+++ b/src/media/decode/decode.cpp
@@ -261,7 +261,17 @@ public:
                            (descriptor->flags & AV_PIX_FMT_FLAG_ALPHA) != 0;
         const int channels = alpha ? 4 : 3;
         std::vector<std::uint8_t> converted(static_cast<std::size_t>(width) * height * channels);
-        sws_ = sws_getCachedContext(sws_, width, height, static_cast<AVPixelFormat>(frame->format),
+        const AVPixelFormat src_format = static_cast<AVPixelFormat>(frame->format);
+        // FFmpeg 6.1's libswscale has a bug where sws_getCachedContext/sws_scale corrupt the heap
+        // when handling deprecated AV_PIX_FMT_YUVJ* pixel formats produced by the JPEG decoder.
+        // These formats have identical memory layouts to their AV_PIX_FMT_YUV* equivalents --
+        // the only difference is color range metadata. Convert them before passing to swscaler.
+        AVPixelFormat safe_src = src_format;
+        if (src_format == AV_PIX_FMT_YUVJ420P) { safe_src = AV_PIX_FMT_YUV420P; }
+        else if (src_format == AV_PIX_FMT_YUVJ422P) { safe_src = AV_PIX_FMT_YUV422P; }
+        else if (src_format == AV_PIX_FMT_YUVJ444P) { safe_src = AV_PIX_FMT_YUV444P; }
+        else if (src_format == AV_PIX_FMT_YUVJ411P) { safe_src = AV_PIX_FMT_YUV411P; }
+        sws_ = sws_getCachedContext(sws_, width, height, safe_src,
                                     width, height, alpha ? AV_PIX_FMT_RGBA : AV_PIX_FMT_RGB24,
                                     SWS_POINT, nullptr, nullptr, nullptr);
         if (sws_ == nullptr) { throw std::runtime_error("failed to create media color converter"); }


### PR DESCRIPTION
## Summary

Fixes `malloc(): corrupted top size` crash on vision requests with JPEG images (e.g., from Wikimedia).

## Root Cause

FFmpeg 6.1's `libswscale` has a bug where `sws_getCachedContext`/`sws_scale` corrupt the heap when handling deprecated `AV_PIX_FMT_YUVJ*` pixel formats produced by the JPEG decoder. The swscaler emits a "deprecated pixel format used" warning then crashes with heap corruption during color conversion.

## Fix

Convert deprecated `AV_PIX_FMT_YUVJ*` formats to their standard `AV_PIX_FMT_YUV*` equivalents before passing them to `sws_getCachedContext`. These formats have identical memory layouts -- the only difference is color range metadata, which doesn't affect how swscaler reads pixel data.

**Affected formats:**
- `AV_PIX_FMT_YUVJ420P` → `AV_PIX_FMT_YUV420P`
- `AV_PIX_FMT_YUVJ422P` → `AV_PIX_FMT_YUV422P`
- `AV_PIX_FMT_YUVJ444P` → `AV_PIX_FMT_YUV444P`
- `AV_PIX_FMT_YUVJ411P` → `AV_PIX_FMT_YUV411P`

## Testing

Verified stable operation with multiple concurrent vision requests using JPEG images from Wikimedia Commons after applying the fix.

## Related

- FFmpeg version: 6.1.1-3ubuntu5 (libswscale 7.5.100)
- NInfer requires: libswscale>=7
- Platform: NVIDIA RTX 5090, sm_120a